### PR TITLE
Basic logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1427,6 +1427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1577,8 @@ dependencies = [
  "nih_plug",
  "nih_plug_egui",
  "parking_lot",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1665,6 +1673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +1855,36 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow 0.6.24",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "rx11"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "rx11_standalone"
+path = "src/main.rs"
+
 [lib]
 # The `lib` artifact is needed for the standalone target
 crate-type = ["cdylib", "lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [lib]
 # The `lib` artifact is needed for the standalone target
-#name = "rx11_lib"
 crate-type = ["cdylib", "lib"]
 
 [workspace]
@@ -15,4 +14,6 @@ members = ["xtask"]
 parking_lot = "0.12"
 nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["assert_process_allocs", "standalone"] }
 nih_plug_egui = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+tracing = { version = "0.1.40", default-features = false }
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["registry"] }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Metadata, Subscriber};
+
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+#[derive(Debug, Clone)]
+pub struct CollectedEvent {
+    pub target: String,
+    pub level: tracing::Level,
+    pub fields: BTreeMap<String, String>,
+}
+
+impl CollectedEvent {
+    pub fn new(event: &Event, meta: &Metadata) -> Self {
+        let mut fields = BTreeMap::new();
+        event.record(&mut FieldVisitor(&mut fields));
+
+        Self {
+            level: meta.level().to_owned(),
+            target: meta.target().to_owned(),
+            fields,
+        }
+    }
+}
+
+struct FieldVisitor<'a>(&'a mut BTreeMap<String, String>);
+
+impl<'a> Visit for FieldVisitor<'a> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{:?}", value));
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AllowedTargets {
+    All,
+    Selected(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+pub struct EventCollector {
+    allowed_targets: AllowedTargets,
+    level: Level,
+    events: Arc<Mutex<Vec<CollectedEvent>>>,
+}
+
+impl EventCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_level(self, level: Level) -> Self {
+        Self { level, ..self }
+    }
+
+    pub fn allowed_targets(self, allowed_targets: AllowedTargets) -> Self {
+        Self {
+            allowed_targets,
+            ..self
+        }
+    }
+
+    pub fn events(&self) -> Vec<CollectedEvent> {
+        self.events.lock().unwrap().clone()
+    }
+
+    pub fn clear(&self) {
+        let mut events = self.events.lock().unwrap();
+        *events = Vec::new();
+    }
+
+    fn collect(&self, event: CollectedEvent) {
+        if event.level <= self.level {
+            let should_collect = match self.allowed_targets {
+                AllowedTargets::All => true,
+                AllowedTargets::Selected(ref selection) => selection
+                    .iter()
+                    .any(|target| event.target.starts_with(target)),
+            };
+
+            if should_collect {
+                self.events.lock().unwrap().push(event);
+            }
+        }
+    }
+}
+
+impl Default for EventCollector {
+    fn default() -> Self {
+        Self {
+            allowed_targets: AllowedTargets::All,
+            events: Arc::new(Mutex::new(Vec::new())),
+            level: Level::TRACE,
+        }
+    }
+}
+
+impl<S> Layer<S> for EventCollector
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+
+        self.collect(CollectedEvent::new(event, meta));
+    }
+}


### PR DESCRIPTION
Write a basic logger implementation following how the `egui_tracing` create implemented a tracing_subscriber layer. Also, renamed the bin because Windows builds were displaying an annoying warning. Renaming the lib caused some other issues where the VST3 plugin wasn't getting the right lib, resulting in the changes never showing up when loading from a DAW.